### PR TITLE
Add Ajax functionality and configure SlimSelect through data attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# CHANGELOG
+
+## master
+
+* Add AJAX search functionality and configure SlimSelect + Ajax through data attributes.
+
+    *Sjors Baltus*
+
+## 0.1.0
+
+* Initial release
+
+    *Chris Oliver*

--- a/README.md
+++ b/README.md
@@ -45,6 +45,55 @@ application.register('slimselect', StimulusSlimSelect)
 This will start StimulusJS and load any controllers that you have
 locally and then register the Stimulus SlimSelect controller.
 
+### Configure SlimSelect using data attributes
+
+To supply additional options to SlimSelect include them as data attributes, booleans will automatically be casted:
+
+```html
+<select
+  id="product_id"
+  name="product_id"
+  data-placeholder="This is used as the placeholder"
+  data-allow-deselect="true"
+/>
+```
+
+*Note*: the attributes will automatically be converted from kebab-case to camelCase as required by SlimSelect.
+
+## AJAX Usage
+
+This wrapper allows you to make AJAX calls for the searches and configure it through data attributes. The following attributes are exposed:
+
+| Command | Default | Description |
+| --- | --- | --- |
+| `ajaxUrl` | - | Url used to make the AJAX call (Supply a path `/` or complete url) |
+| `ajaxUrlParam` | search | Parameter that holds the search term |
+| `ajaxMinimumLength` | 2 | If the search term is shorter or equal to this number the AJAX call will not be executed |
+| `ajaxMinimumLengthMessage` | false | Message shown when the ajaxMinimumLength is not reached |
+| `ajaxRootColumn` | | Column that holds the result array (dot notation) |
+| `ajaxValueColumn` | value | Column that holds the value (dot notation) |
+| `ajaxTextColumn` | text | Column that holds the text/label (dot notation) |
+| `ajaxDebounceMs` | 175 | Ajax calls are debounced to not overload the server (in miliseconds) |
+
+### Dot notation
+
+By using the dot notation you are able to dig into the object to get the right results. Use as follows:
+
+```javascript
+{
+  data: {
+    products: [{ value: 'id1', text: 'Label' }],
+    otherColumn: 'test'
+  }
+}
+```
+
+By supplying `data.products` as the `ajaxRootColumn` value it will use the Array that holds:
+
+```javascript
+[{ value: 'id1', text: 'Label' }]
+```
+
 ## Extending Components
 
 You can use inheritance to extend the functionality of any Stimulus components.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "tests": false
   },
   "peerDependencies": {
-    "slim-select": "^1.27.0",
-    "stimulus": ">=2.0.0"
+    "slim-select": "1.26.1",
+    "stimulus": ">=2.0.0",
+    "jsdig": ">=0.1.4"
   },
   "scripts": {
     "build": "microbundle --globals stimulus=Stimulus",

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,115 @@
-import { Controller } from 'stimulus'
-import SlimSelect from 'slim-select'
-
+import { Controller } from "stimulus";
+import SlimSelect from 'slim-select';
+import 'jsdig';
 export default class extends Controller {
   connect() {
-    this.slimselect = new SlimSelect({
-      select: this.element
-    })
+    this.slimselect = new SlimSelect(this._slimSelectOptions());
   }
 
   disconnect() {
     this.slimselect.destroy()
+  }
+
+  _ajax({ url, urlParam, minimumLength, minimumLengthMessage, debounceMs, ...processAjaxResultConfig }) {
+    return this._debounce((search, callback) => {
+      if (search.length < minimumLength) {
+        callback(minimumLengthMessage);
+        return;
+      }
+
+      url.searchParams.set(urlParam, search);
+      fetch(url)
+        .then(function (response) {
+          return response.json()
+        })
+        .then(function (json) {
+          const data = this._processAjaxResult(json, processAjaxResultConfig);
+          callback(data);
+        }.bind(this))
+        .catch(function(_error) {
+          console.error(_error);
+          callback(false);
+        });
+    }, debounceMs);
+  }
+
+  _processAjaxResult(data, { valueColumn, textColumn, rootColumn }) {
+    let root = data;
+    if(rootColumn) root = data.dig(rootColumn);
+
+    return root.map(el => {
+      return {
+        value: el.dig(...valueColumn.split('.')),
+        text: el.dig(...textColumn.split('.'))
+      }
+    })
+  }
+
+  _slimSelectOptions() {
+    return Object.assign(
+      { select: this.element },
+      this._castOptions({ ...this.element.dataset }),
+      this._ajaxOptions()
+    )
+  }
+
+  _castOptions(data) {
+    return Object.keys(data).reduce((acc, current) => {
+      if (data[current] === "true") {
+        acc[current] = true;
+      } else if (data[current] === "false") {
+        acc[current] = false;
+      } else {
+        acc[current] = data[current];
+      }
+      return acc;
+    }, {})
+  }
+
+  _ajaxOptions() {
+    if (!this.element.dataset.ajaxUrl) return {}
+    const data = this.element.dataset;
+
+    return {
+      ajax: this._ajax({
+        url: this._ajaxUrl(data.ajaxUrl),
+        urlParam: data.ajaxUrlParam || 'search',
+        minimumLength: data.ajaxMinimumLength || 2,
+        minimumLengthMessage: data.ajaxMinimumLengthMessage || false,
+        valueColumn: data.ajaxValueColumn || 'value',
+        textColumn: data.ajaxTextColumn || 'text',
+        rootColumn: data.ajaxRootColumn || null,
+        debounceMs: parseInt(data.ajaxDebounceMs || 175)
+      }),
+      searchFilter: (_option, _search) => true
+    }
+  }
+
+  _ajaxUrl(urlOrPath) {
+    try {
+      return new URL(urlOrPath)
+    } catch (_) {
+      // If the developer only gave a path, combine it with the domain + protocol
+      const baseUrl = window.location.href.split('/').slice(0, 3).join('/');
+      const url = new URL(baseUrl)
+      url.pathname = urlOrPath;
+      return url
+    }
+  }
+
+  _debounce(callback, wait, immediate = false) {
+    let timeout = null
+
+    return function() {
+      const callNow = immediate && !timeout
+      const next = () => callback.apply(this, arguments)
+
+      clearTimeout(timeout)
+      timeout = setTimeout(next, wait)
+
+      if (callNow) {
+        next()
+      }
+    }
   }
 }


### PR DESCRIPTION
Hi Chris,

Thank you for the RemoteRuby podcast, it's awesome! Here is a little PR to improve the SlimSelect integration with your package that allows the user to add AJAX calls and configure SlimSelect without the need to extend the component. It's not yet linted as that tend to differ between developer setups.

I also added a CHANGELOG and extended the README file.

ps: I pinned the version of SlimSelect to 1.26.1 as that is the latest working version that supports AJAX calls. I made a PR to resolve the issue, but i'm not sure when the new version of SlimSelect will be released. https://github.com/brianvoe/slim-select/pull/270