### PR TITLE
Adds the ability to pass slim-select options into the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ application.register('slimselect', StimulusSlimSelect)
 This will start StimulusJS and load any controllers that you have
 locally and then register the Stimulus SlimSelect controller.
 
+## Values
+- Options: `Object`
+
+You can add any options from [slim-select](https://github.com/brianvoe/slim-select/blob/master/src/docs/pages/options.vue) 
+into the component, simply do
+
+```html
+<select 
+    data-controller="slimselect" 
+    data-slimselect-options-value="{slim-select options}">
+
+</select>
+```
+
 ## Extending Components
 
 You can use inheritance to extend the functionality of any Stimulus components.

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,19 @@
-import { Controller } from 'stimulus'
-import SlimSelect from 'slim-select'
+import { Controller } from 'stimulus';
+import SlimSelect from 'slim-select';
 
 export default class extends Controller {
+  static values = {
+    options: Object
+  };
+
   connect() {
     this.slimselect = new SlimSelect({
-      select: this.element
-    })
+      select: this.element,
+      ...this.optionsValue
+    });
   }
 
   disconnect() {
-    this.slimselect.destroy()
+    this.slimselect.destroy();
   }
 }


### PR DESCRIPTION
Hi, first of all thanks so much for this pacakge.

So, i needed to pass some slim-select options into this component, but found out that it dosen't support it, so this adds the ability to pass any options from [slim-select](https://github.com/brianvoe/slim-select/blob/master/src/docs/pages/options.vue) into the component, like so. Currently im using it in my codebase like this

```erb
data: { controller: "myslimselect", myslimselect_options_value: {deselectLabel: '<span class="text-xl text-red-500">+++</span>'} }
```

Thanks!!